### PR TITLE
Changed autosummary module template

### DIFF
--- a/doc/_templates/module.rst
+++ b/doc/_templates/module.rst
@@ -1,0 +1,7 @@
+{{ ["Module ", fullname] | join | escape | underline}}
+
+.. automodule:: {{ fullname }}
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :private-members:

--- a/doc/apidoc.rst
+++ b/doc/apidoc.rst
@@ -2,17 +2,13 @@ qutip\_qoc package
 ===================
 
 
-.. toctree::
-   :maxdepth: 1
-
-
 High-level interfaces
 ---------------------
 High-level interfaces to the optimal control features.
 
 .. autosummary::
    :toctree: apidoc/
-   :template: apidoc/module.rst
+   :template: module.rst
 
    qutip_qoc.pulse_optim
 
@@ -23,7 +19,7 @@ Optimal control utility functions.
 
 .. autosummary::
    :toctree: apidoc/
-   :template: apidoc/module.rst
+   :template: module.rst
 
    qutip_qoc.result
    qutip_qoc.objective
@@ -34,7 +30,7 @@ Internal interfaces to the optimal control features.
 
 .. autosummary::
    :toctree: apidoc/
-   :template: apidoc/module.rst
+   :template: module.rst
 
    qutip_qoc._optimizer
    qutip_qoc._goat

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -78,7 +78,6 @@ napoleon_use_admonition_for_notes = True
 # functions/classes. However, pay attention that some api docs files are
 # adjusted manually for better illustration and should not be overwritten.
 autosummary_generate = True
-autosummary_imported_members = True
 
 # -- Options for biblatex ---------------------------------------
 


### PR DESCRIPTION
I had a look at the broken apidocs. Unfortunately I missed that there already was a branch / PR about that. Feel free to decide if this looks good to you, or to ignore this.

On my system, the apidocs are not properly generated on the master branch, but with the changes here it works. I don't know how to generate the readthedocs to try whether it works there.