### PR TITLE
Make all JAX and machine learning related dependencies optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ To install the package, use
 pip install qutip-qoc
 ```
 
+By default, the dependencies required for JOPT and for the RL (reinforcement learning) algorithm are omitted.
+They can be included by using the targets `qutip-qoc[jopt]` and `qutip-qoc[rl]`, respectively (or `qutip-qoc[full]` for all dependencies).
+
 ## Documentation and tutorials
 
 The documentation of `qutip-qoc` updated to the latest development version is hosted at [qutip-qoc.readthedocs.io](https://qutip-qoc.readthedocs.io/en/latest/).

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -23,7 +23,19 @@ In particular, the following packages are necessary for running ``qutip-qoc``:
 
 .. code-block:: bash
 
-    numpy scipy jax jaxlib cython qutip qutip-jax qutip-qtrl
+    numpy scipy cython qutip qutip-qtrl
+
+The following packages are required for using the JOPT algorithm:
+
+.. code-block:: bash
+
+    jax jaxlib qutip-jax
+
+The following packages are required for the RL (reinforcement learning) algorithm:
+
+.. code-block:: bash
+
+    gymnasium stable-baselines3
 
 The following package is used for testing:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,6 @@
 cython>=1.0
 numpy>=1.16.6,<2.0
 scipy>=1.10.1
-jax==0.4.28
-jaxlib==0.4.28
 qutip>=5.0.1
 qutip-qtrl
-qutip-jax
 pre-commit
-gymnasium>=0.29.1
-stable-baselines3>=2.3.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,15 +28,10 @@ package_dir=
 packages = find:
 include_package_data = True
 install_requires =
-    jax
-    jaxlib
     packaging
     qutip
     qutip-qtrl
-    qutip-jax
     numpy>=1.16.6,<2.0
-    gymnasium>=0.29.1
-    stable-baselines3>=2.3.2
 setup_requires =
     cython>=1.0
     packaging
@@ -45,7 +40,16 @@ setup_requires =
 where = src
 
 [options.extras_require]
+jopt =
+    jax
+    jaxlib
+    qutip-jax
+rl =
+    gymnasium>=0.29.1
+    stable-baselines3>=2.3.2
 tests =
     pytest>=6.0
 full =
+    %(jopt)s
+    %(rl)s
     %(tests)s

--- a/src/qutip_qoc/_jopt.py
+++ b/src/qutip_qoc/_jopt.py
@@ -5,38 +5,47 @@ calculate optimal parameters for analytical control pulse sequences.
 import qutip as qt
 from qutip import Qobj, QobjEvo
 
-from diffrax import Dopri5, PIDController
+try:
+    import jax
+    from jax import custom_jvp
+    import jax.numpy as jnp
+    import qutip_jax  # noqa: F401
 
-import jax
-from jax import custom_jvp
-import jax.numpy as jnp
-import qutip_jax  # noqa: F401
+    import jaxlib  # noqa: F401
 
+    from diffrax import Dopri5, PIDController
 
-@custom_jvp
-def _abs(x):
-    return jnp.abs(x)
-
-
-def _abs_jvp(primals, tangents):
-    """
-    Custom jvp for absolute value of complex functions
-    """
-    (x,) = primals
-    (t,) = tangents
-
-    abs_x = _abs(x)
-    res = jnp.where(
-        abs_x == 0,
-        0.0,  # prevent division by zero
-        jnp.real(jnp.multiply(jnp.conj(x), t)) / abs_x,
-    )
-
-    return abs_x, res
+    _jax_available = True
+except ImportError:
+    _jax_available = False
 
 
-# register custom jvp for absolut value of complex functions
-_abs.defjvp(_abs_jvp)
+if _jax_available:
+
+    @custom_jvp
+    def _abs(x):
+        return jnp.abs(x)
+
+
+    def _abs_jvp(primals, tangents):
+        """
+        Custom jvp for absolute value of complex functions
+        """
+        (x,) = primals
+        (t,) = tangents
+
+        abs_x = _abs(x)
+        res = jnp.where(
+            abs_x == 0,
+            0.0,  # prevent division by zero
+            jnp.real(jnp.multiply(jnp.conj(x), t)) / abs_x,
+        )
+
+        return abs_x, res
+
+
+    # register custom jvp for absolut value of complex functions
+    _abs.defjvp(_abs_jvp)
 
 
 class _JOPT:
@@ -55,6 +64,10 @@ class _JOPT:
         guess_params,
         **integrator_kwargs,
     ):
+        if not _jax_available:
+            raise ImportError("The JOPT algorithm requires the modules jax, "
+                              "jaxlib, and qutip_jax to be installed.")
+
         self._Hd = objective.H[0]
         self._Hc_lst = objective.H[1:]
 

--- a/src/qutip_qoc/pulse_optim.py
+++ b/src/qutip_qoc/pulse_optim.py
@@ -10,7 +10,12 @@ import qutip_qtrl.pulseoptim as cpo
 
 from qutip_qoc._optimizer import _global_local_optimization
 from qutip_qoc._time import _TimeInterval
-from qutip_qoc._rl import _RL
+
+try:
+    from qutip_qoc._rl import _RL
+    _rl_available = True
+except ImportError:
+    _rl_available = False
 
 __all__ = ["optimize_pulses"]
 
@@ -353,6 +358,12 @@ def optimize_pulses(
             qtrl_optimizers.append(qtrl_optimizer)
 
     elif alg == "RL":
+        if not _rl_available:
+            raise ImportError(
+                "The required dependencies (gymnasium, stable-baselines3) for "
+                "the reinforcement learning algorithm are not available."
+            )
+
         rl_env = _RL(
             objectives,
             control_parameters,

--- a/src/qutip_qoc/result.py
+++ b/src/qutip_qoc/result.py
@@ -2,7 +2,6 @@
 This module contains the Result class for storing and
 reporting the results of a full pulse control optimization run.
 """
-import jaxlib
 import pickle
 import textwrap
 import numpy as np
@@ -10,6 +9,12 @@ from inspect import signature
 import warnings
 
 import qutip as qt
+
+try:
+    import jaxlib
+    _jitfun_type = jaxlib.xla_extension.PjitFunction
+except ImportError:
+    _jitfun_type = None
 
 __all__ = ["Result"]
 
@@ -331,8 +336,10 @@ class Result:
                 evo_time = self.time_interval.evo_time
 
             # choose solver method based on type of control function
-            if isinstance(
-                self.objectives[0].H[1][1], jaxlib.xla_extension.PjitFunction
+            # if jax is installed, _jitfun_type is set to
+            # jaxlib.xla_extension.PjitFunction, otherwise it is None
+            if _jitfun_type is not None and isinstance(
+                self.objectives[0].H[1][1], _jitfun_type
             ):
                 method = "diffrax"  # for JAX defined contols
             else:

--- a/src/qutip_qoc/result.py
+++ b/src/qutip_qoc/result.py
@@ -11,6 +11,7 @@ import warnings
 import qutip as qt
 
 try:
+    import jax
     import jaxlib
     _jitfun_type = jaxlib.xla_extension.PjitFunction
 except ImportError:


### PR DESCRIPTION
The JOPT and RL algorithms come with very heavy dependencies, which don't need to be installed for every user. This PR adds targets "jopt" and "rl" so that one can use `pip install qutip-qoc [jopt]` or `pip install qutip-qoc [rl]` to include these dependencies, otherwise they are omitted. The full installation (as it was previously) can be obtained with `pip install qutip-qoc [full]`.

I updated the code to still work if these dependencies are not installed, as long as these algorithms are not invoked, and made the tests skip if the dependencies are not installed. Someone please double-check if I missed anything, but I have checked that the tests pass in all installation configurations.

This PR does not fix issue #30 but should improve things somewhat, since everything still works on Windows if the RL dependencies are not installed.