### PR TITLE
Update versions of action tools

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build a binary wheel and a source tarball
         run: python3 -m cibuildwheel --output-dir dist
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: python-package-distributions
           path: dist/
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: python-package-distributions
           path: dist/

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v4
         name: Install Python
@@ -42,7 +42,7 @@ jobs:
           #   -T : display a full traceback if a Python exception occurs
 
       - name: Upload built files
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: qutip_qoc_html_docs
           path: doc/_build/html/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
             python-version: "3.12"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
Currently, documentation builds are failing because: "Starting January 30th, 2025, GitHub Actions customers will no longer be able to use v3 of [actions/upload-artifact](https://github.com/actions/upload-artifact) or [actions/download-artifact](https://github.com/actions/download-artifact). Customers should update workflows to begin using [v4 of the artifact actions](https://github.blog/2024-02-12-get-started-with-v4-of-github-actions-artifacts/) as soon as possible."

Updating all tools versions from v3 to v4, in parallel to https://github.com/qutip/qutip/pull/2430