### PR TITLE
Fixing README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ They can be included by using the targets `qutip-qoc[jopt]` and `qutip-qoc[rl]`,
 
 ## Documentation and tutorials
 
-The documentation of `qutip-qoc` updated to the latest development version is hosted at [qutip-qoc.readthedocs.io](https://qutip-qoc.readthedocs.io/en/latest/).
+The documentation of `qutip-qoc` updated to the latest development version is hosted at [qutip-qoc.readthedocs.io](https://qutip-qoc.readthedocs.io/latest/).
 Tutorials related to using quantum optimal control in `qutip-qoc` can be found [_here_](https://qutip.org/qutip-tutorials/#optimal-control).
 
 ## Installation from source
@@ -43,7 +43,7 @@ pip install --upgrade pip
 pip install -e .
 ```
 
-which makes sure that you are up to date with the latest `pip` version. Contribution guidelines are available [_here_](https://qutip-qoc.readthedocs.io/en/latest/contribution-code.html).
+which makes sure that you are up to date with the latest `pip` version. Contribution guidelines are available [_here_](https://qutip-qoc.readthedocs.io/latest/contribution/code.html).
 
 To build and test the documentation, additional packages need to be installed:
 

--- a/doc/contribution/code.rst
+++ b/doc/contribution/code.rst
@@ -7,7 +7,7 @@ Contributing to the source code
 Build up an development environment
 ===================================
 
-Please follow the instruction on the `QuTiP contribution guide <https://qutip.org/docs/latest/development/contributing.html#building>`_ to
+Please follow the instruction on the `QuTiP contribution guide <https://qutip.readthedocs.io/en/latest/development/contributing.html>`_ to
 build a conda environment.
 
 You don't need to build ``qutip`` in the editable mode unless you also want to contribute to `qutip`.


### PR DESCRIPTION
Fixes #37 

@pmenczel There seems to be another broken link in `qutip-qoc/doc/contribution/code.rst` as `QuTiP contribution guide`. I managed to find a link from an earlier version, `4.7` ([Link](https://qutip.org/docs/4.7/development/contributing.html)). Maybe you could help me find the latest link for fixing it in this PR?