### PR TITLE
Fix: Load jQuery explicitly to resolve broken search panel on deployed docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -62,6 +62,10 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 html_theme = "sphinx_rtd_theme"
 html_static_path = []
+html_js_files = [
+    'https://code.jquery.com/jquery-3.6.0.min.js',
+]
+
 
 # -- Options for numpydoc ---------------------------------------
 


### PR DESCRIPTION
- Console error indicated that jQuery was missing in the deployed version.

- Search panel works correctly in local builds where jQuery is likely implicitly available.

- Added jQuery explicitly via CDN using html_js_files in conf.py:

```
html_js_files = [
    'https://code.jquery.com/jquery-3.6.0.min.js',
]
```

- Ensures jQuery is loaded before dependent scripts execute.