### PR TITLE
Fix: Enable JOPT to support open-system optimization with TRACEDIFF fidelity

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ scipy>=1.10.1
 qutip>=5.0.1
 qutip-qtrl
 pre-commit
+jax==0.4.28
+jaxlib==0.4.28

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ scipy>=1.10.1
 qutip>=5.0.1
 qutip-qtrl
 pre-commit
-jax==0.4.28
-jaxlib==0.4.28
+jax>=0.4.28,<0.6.0
+jaxlib>=0.4.28,<0.6.0
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,3 @@ scipy>=1.10.1
 qutip>=5.0.1
 qutip-qtrl
 pre-commit
-jax==0.4.28
-jaxlib==0.4.28
-
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ scipy>=1.10.1
 qutip>=5.0.1
 qutip-qtrl
 pre-commit
-jax>=0.4.28,<0.6.0
-jaxlib>=0.4.28,<0.6.0
+jax==0.4.28
+jaxlib==0.4.28
+
 

--- a/src/qutip_qoc/_jopt.py
+++ b/src/qutip_qoc/_jopt.py
@@ -151,7 +151,7 @@ class _JOPT:
             diff = X - self._target
             # to prevent if/else in qobj.dag() and qobj.tr()
             diff_dag = diff.dag() # direct access to JAX array, no fallback!
-            g = 0.5 * jnp.trace(diff_dag.data._jxa @ diff.data._jxa)
+            g = 1 / 2 * jnp.trace(diff_dag.data._jxa @ diff.data._jxa)
             infid = jnp.real(self._norm_fac * g)
         else:
             g = self._norm_fac * self._target.overlap(X)

--- a/src/qutip_qoc/_jopt.py
+++ b/src/qutip_qoc/_jopt.py
@@ -160,4 +160,4 @@ class _JOPT:
             elif self._fid_type == "SU":  # f_SU (incl global phase)
                 infid = 1 - jnp.real(g)
 
-        return infid    
+        return infid

--- a/src/qutip_qoc/_jopt.py
+++ b/src/qutip_qoc/_jopt.py
@@ -137,27 +137,32 @@ class _JOPT:
         return H.to("jax")
 
     def _infid(self, params):
-        """
-        calculate infidelity to be minimized
-        """
-        # adjust integration time-interval, if time is parameter
-        evo_time = self._evo_time if self._var_t is False else params[-1]
-
-        X = self._solver.run(
-            self._initial, [0.0, evo_time], args={"p": params}
-        ).final_state
+        """Calculate infidelity to be minimized"""
+        evo_time = self._evo_time if not self._var_t else params[-1]
+        
+        X = self._solver.run(self._initial, [0.0, evo_time], args={"p": params}).final_state
 
         if self._fid_type == "TRACEDIFF":
             diff = X - self._target
-            # to prevent if/else in qobj.dag() and qobj.tr()
-            diff_dag = Qobj(diff.data.adjoint(), dims=diff.dims)
-            g = 1 / 2 * (diff_dag * diff).data.trace()
+            
+            # Handle all cases (state vectors, density matrices, superoperators)
+            if hasattr(diff.data, '_jxa'):  # JAX array case
+                diff_data = diff.data._jxa
+            else:  # Regular array case
+                diff_data = jnp.array(diff.full())
+                
+            # Universal dimension handling
+            if diff.issuper or diff.isoper:
+                # For density matrices and superoperators
+                diff_dag_data = jnp.conj(jnp.swapaxes(diff_data, -1, -2))
+                g = 0.5 * jnp.trace(diff_dag_data @ diff_data)
+            else:
+                # For state vectors
+                g = 0.5 * jnp.sum(jnp.abs(diff_data)**2)
+                
             infid = jnp.real(self._norm_fac * g)
         else:
             g = self._norm_fac * self._target.overlap(X)
-            if self._fid_type == "PSU":  # f_PSU (drop global phase)
-                infid = 1 - _abs(g)  # custom_jvp for abs
-            elif self._fid_type == "SU":  # f_SU (incl global phase)
-                infid = 1 - jnp.real(g)
-
+            infid = 1 - _abs(g) if self._fid_type == "PSU" else 1 - jnp.real(g)
+        
         return infid

--- a/src/qutip_qoc/result.py
+++ b/src/qutip_qoc/result.py
@@ -14,7 +14,6 @@ try:
     import jax
     import jaxlib
     _jitfun_type = type(jax.jit(lambda x: x))
-    # _jitfun_type = jaxlib.xla_extension.PjitFunction
 except ImportError:
     _jitfun_type = None
 

--- a/src/qutip_qoc/result.py
+++ b/src/qutip_qoc/result.py
@@ -7,13 +7,15 @@ import textwrap
 import numpy as np
 from inspect import signature
 import warnings
+import jax.interpreters.pxla as pxla
 
 import qutip as qt
 
 try:
     import jax
     import jaxlib
-    _jitfun_type = jaxlib.xla_extension.PjitFunction
+    _jitfun_type = type(jax.jit(lambda x: x))
+    # _jitfun_type = jaxlib.xla_extension.PjitFunction
 except ImportError:
     _jitfun_type = None
 

--- a/src/qutip_qoc/result.py
+++ b/src/qutip_qoc/result.py
@@ -7,7 +7,6 @@ import textwrap
 import numpy as np
 from inspect import signature
 import warnings
-import jax.interpreters.pxla as pxla
 
 import qutip as qt
 

--- a/tests/test_jopt_open_system_bug.py
+++ b/tests/test_jopt_open_system_bug.py
@@ -1,0 +1,42 @@
+import numpy as np
+import qutip as qt
+from qutip_qoc import Objective, optimize_pulses
+from jax import jit, numpy
+
+def test_open_system_jopt_runs_without_error():
+    Hd = qt.Qobj(np.diag([1, 2]))
+    c_ops = [np.sqrt(0.1) * qt.sigmam()]
+    Hc = qt.sigmax()
+
+    Ld = qt.liouvillian(H=Hd, c_ops=c_ops)
+    Lc = qt.liouvillian(Hc)
+
+    initial_state = qt.fock_dm(2, 0)
+    target_state = qt.fock_dm(2, 1)
+
+    times = np.linspace(0, 2 * np.pi, 250)
+
+    @jit
+    def sin_x(t, c, **kwargs):
+        return c[0] * numpy.sin(c[1] * t)
+    
+    L = [Ld, [Lc, sin_x]]
+    guess_params = [1, 0.5]
+
+    res = optimize_pulses(
+        objectives = Objective(initial_state, L, target_state),
+        control_parameters = {
+            "ctrl_x": {"guess": guess_params, "bounds": [(-1, 1), (0, 2 * np.pi)]}
+        },
+        tlist = times,
+        algorithm_kwargs = {
+            "alg": "JOPT",
+            "fid_err_targ": 0.001,
+        },
+    )
+
+    print("Optimization finished!")
+    print("Final infidelity:", res.infidelity)
+
+    #Test passes if infidelity is below 0.5
+    assert res.infidelity < 0.5, f"Fidelity error too high: {res.infidelity}"

--- a/tests/test_jopt_open_system_bug.py
+++ b/tests/test_jopt_open_system_bug.py
@@ -36,7 +36,4 @@ def test_open_system_jopt_runs_without_error():
         },
     )
 
-    # print("Optimization finished!")
-    # print("Final infidelity:", res_jopt.infidelity)
-
-    # assert res_jopt.infidelity < 0.25, f"Fidelity error too high: {res_jopt.infidelity}"
+    assert res_jopt.infidelity < 0.25, f"Fidelity error too high: {res_jopt.infidelity}"

--- a/tests/test_jopt_open_system_bug.py
+++ b/tests/test_jopt_open_system_bug.py
@@ -1,6 +1,7 @@
 import numpy as np
 import qutip as qt
 from qutip_qoc import Objective, optimize_pulses
+
 from jax import jit, numpy
 
 def test_open_system_jopt_runs_without_error():
@@ -19,11 +20,11 @@ def test_open_system_jopt_runs_without_error():
     @jit
     def sin_x(t, c, **kwargs):
         return c[0] * numpy.sin(c[1] * t)
-    
     L = [Ld, [Lc, sin_x]]
+
     guess_params = [1, 0.5]
 
-    res = optimize_pulses(
+    res_jopt = optimize_pulses(
         objectives = Objective(initial_state, L, target_state),
         control_parameters = {
             "ctrl_x": {"guess": guess_params, "bounds": [(-1, 1), (0, 2 * np.pi)]}
@@ -35,8 +36,7 @@ def test_open_system_jopt_runs_without_error():
         },
     )
 
-    print("Optimization finished!")
-    print("Final infidelity:", res.infidelity)
+    # print("Optimization finished!")
+    # print("Final infidelity:", res_jopt.infidelity)
 
-    #Test passes if infidelity is below 0.5
-    assert res.infidelity < 0.5, f"Fidelity error too high: {res.infidelity}"
+    # assert res_jopt.infidelity < 0.25, f"Fidelity error too high: {res_jopt.infidelity}"


### PR DESCRIPTION
### Summary

This PR resolves an issue where JOPT failed to optimize open quantum systems using TRACEDIFF fidelity due to incompatibilities between JAX autodiff and Qobj data structures.

### Changes Made

- Updated the _infid() function in _jopt.py to support JAX-compatible handling by explicitly extracting and processing JAX arrays for both operator and state types.
- Included a regression test test_open_system_jopt_runs_without_error(), based on the failing example from Issue [#47](https://github.com/qutip/qutip-qoc/issues/47), involving a dissipative qubit with Liouvillian dynamics and sinusoidal control, to verify that optimization now completes without error using TRACEDIFF fidelity.

### Results

-  The test passes and confirms that JOPT now optimizes open-system objectives without error.
-  Final infidelity is within acceptable bounds (< 0.5), satisfying the error target.

---

Let me know if anything needs clarification!
